### PR TITLE
Improve test environment with mocks and BDD naming

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,9 +20,9 @@ failures. With pnpm, dependency test files live under `node_modules/.pnpm/` (a d
 ### Running things
 
 - Lint / typecheck: `pnpm run lint` (just `tsc --noEmit`).
-- Tests: `pnpm run test` (node's built-in test runner via `tsx`). Some tests make **real
-  network requests** to `api.github.com` and `echo.hoppscotch.io`, so they require internet
-  access; failures there may be network-related rather than code bugs.
+- Tests: `pnpm run test` (node's built-in test runner via `tsx`). HTTP calls are mocked via
+  `tests/helpers/mock-fetch.ts` (no real third-party network requests). Tests use BDD-style
+  `describe` / `it` naming.
 - Build: `pnpm run build` (`tsup`). pnpm reports esbuild's install script as "ignored", but the
   build still succeeds because `tsup` bundles its own esbuild — you do not need to approve build
   scripts for the build to work.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "tsup src/index.ts --format cjs,esm --dts --minify",
     "lint": "tsc",
     "changeset": "changeset",
-    "test": "glob -c \"node --import tsx --no-warnings --test\" \"./**/*.test.ts\""
+    "test": "glob -c \"node --import tsx --no-warnings --test\" \"./tests/**/*.test.ts\""
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.1",

--- a/tests/get.test.ts
+++ b/tests/get.test.ts
@@ -1,102 +1,165 @@
-import { test, it, describe } from "node:test";
-import { equal } from "node:assert";
+//* Libraries imports
+import { describe, it, afterEach, mock } from "node:test";
 import assert from "node:assert";
-
 import z from "zod";
 
+//* Local imports
 import { Spellbinder, SpellError } from "../src";
+import { mockFetch, jsonResponse } from "./helpers/mock-fetch";
 
-test("Spellbinder get test", async () => {
-  // await it("should return the correct data from github", async () => {
-
-  //   const spellbinder = new Spellbinder({
-  //     baseUrl: "https://api.github.com/",
-  //   });
-
-  //   const url = "/users/tamicktom";
-
-  //   const params = { search: 1 };
-
-  //   const schema = z.object({
-  //     login: z.string(),
-  //     id: z.number(),
-  //     followers: z.number(),
-  //     following: z.number(),
-  //     created_at: z.string(),
-  //     updated_at: z.string(),
-  //   });
-
-  //   const response = await spellbinder.get({ url, schema, params });
-
-  //   equal(response.login, "Tamicktom");
-  //   equal(response.id, 60244227);
-  //   equal(response.created_at, "2020-01-24T00:19:27Z");
-  // });
-
-  await it("should throw an error if the schema is not correct", async () => {
-    const url = "/users/tamicktom";
-    const spellbinder = new Spellbinder({ baseUrl: "https://api.github.com/" });
-
-    const schema = z.object({
-      login: z.string(),
-      id: z.number(),
-      followers: z.number(),
-      following: z.number(),
-      created_at: z.string(),
-      updated_at: z.string(),
+describe("Spellbinder", () => {
+  describe("get", () => {
+    afterEach(() => {
+      mock.restoreAll();
     });
 
-    try {
-      const banna = await spellbinder.get({ url, schema: schema.array() });
-    } catch (error) {
-      assert(error instanceof SpellError);
-    }
-  });
+    it("returns validated data when the response matches the schema", async () => {
+      const githubUser = {
+        login: "Tamicktom",
+        id: 60244227,
+        followers: 10,
+        following: 5,
+        created_at: "2020-01-24T00:19:27Z",
+        updated_at: "2024-01-01T00:00:00Z",
+      };
 
-  await it("should throw an error if the url is not correct", async () => {
-    const url = "users";
-    const spellbinder = new Spellbinder({ baseUrl: "https://api.github.com" });
+      mockFetch(() => jsonResponse(githubUser));
 
-    const schema = z.object({
-      login: z.string(),
-      id: z.number(),
-      followers: z.number(),
-      following: z.number(),
-      created_at: z.string(),
-      updated_at: z.string(),
+      const spellbinder = new Spellbinder({
+        baseUrl: "https://api.github.com/",
+      });
+
+      const schema = z.object({
+        login: z.string(),
+        id: z.number(),
+        followers: z.number(),
+        following: z.number(),
+        created_at: z.string(),
+        updated_at: z.string(),
+      });
+
+      const response = await spellbinder.get({
+        url: "/users/tamicktom",
+        schema,
+        params: { search: 1 },
+      });
+
+      assert.equal(response.login, "Tamicktom");
+      assert.equal(response.id, 60244227);
+      assert.equal(response.created_at, "2020-01-24T00:19:27Z");
     });
 
-    try {
-      await spellbinder.get({ url, schema });
-    } catch (error) {
-      assert(error instanceof SpellError);
-    }
+    it("throws a SpellError when the response does not match the schema", async () => {
+      mockFetch(() =>
+        jsonResponse({
+          login: "Tamicktom",
+          id: 60244227,
+          followers: 10,
+          following: 5,
+          created_at: "2020-01-24T00:19:27Z",
+          updated_at: "2024-01-01T00:00:00Z",
+        })
+      );
+
+      const spellbinder = new Spellbinder({
+        baseUrl: "https://api.github.com/",
+      });
+
+      const schema = z.object({
+        login: z.string(),
+        id: z.number(),
+        followers: z.number(),
+        following: z.number(),
+        created_at: z.string(),
+        updated_at: z.string(),
+      });
+
+      await assert.rejects(
+        () =>
+          spellbinder.get({
+            url: "/users/tamicktom",
+            schema: schema.array(),
+          }),
+        (error: unknown) => error instanceof SpellError
+      );
+    });
+
+    it("throws a SpellError when the response body is incompatible with the schema", async () => {
+      mockFetch(() =>
+        jsonResponse({
+          message: "Not Found",
+          documentation_url: "https://docs.github.com/rest",
+        })
+      );
+
+      const spellbinder = new Spellbinder({
+        baseUrl: "https://api.github.com",
+      });
+
+      const schema = z.object({
+        login: z.string(),
+        id: z.number(),
+        followers: z.number(),
+        following: z.number(),
+        created_at: z.string(),
+        updated_at: z.string(),
+      });
+
+      await assert.rejects(
+        () =>
+          spellbinder.get({
+            url: "users",
+            schema,
+          }),
+        (error: unknown) => error instanceof SpellError
+      );
+    });
+
+    it("forwards next.js cache options to fetch", async () => {
+      const fetchMock = mockFetch(() =>
+        jsonResponse({
+          login: "Tamicktom",
+          id: 60244227,
+          followers: 10,
+          following: 5,
+          created_at: "2020-01-24T00:19:27Z",
+          updated_at: "2024-01-01T00:00:00Z",
+        })
+      );
+
+      const spellbinder = new Spellbinder({
+        baseUrl: "https://api.github.com",
+      });
+
+      const schema = z.object({
+        login: z.string(),
+        id: z.number(),
+        followers: z.number(),
+        following: z.number(),
+        created_at: z.string(),
+        updated_at: z.string(),
+      });
+
+      const nextOptions = {
+        revalidate: 30,
+        tags: ["user"],
+      };
+
+      const response = await spellbinder.get({
+        url: "/users/tamicktom",
+        schema,
+        // Next.js extends RequestInit with a `next` field at runtime.
+        ...({ next: nextOptions } as RequestInit),
+      });
+
+      assert.equal(response.login, "Tamicktom");
+      assert.equal(fetchMock.mock.callCount(), 1);
+
+      const fetchInit = fetchMock.mock.calls[0]?.arguments[1] as
+        | { next?: { revalidate: number; tags: string[] } }
+        | undefined;
+
+      assert.deepEqual(fetchInit?.next, nextOptions);
+    });
   });
-
-  // await it("should be able to use next cache", async () => {
-  //   const url = "/users/tamicktom";
-  //   const spellbinder = new Spellbinder({ baseUrl: "https://api.github.com" });
-
-  //   const schema = z.object({
-  //     login: z.string(),
-  //     id: z.number(),
-  //     followers: z.number(),
-  //     following: z.number(),
-  //     created_at: z.string(),
-  //     updated_at: z.string(),
-  //   });
-
-  //   const response = await spellbinder.get({
-  //     url,
-  //     schema,
-  //     next: {
-  //       revalidate: 30, // 30 seconds
-  //       tags: ["user"],
-  //     },
-  //   });
-
-  //   equal(response.login, "Tamicktom");
-  //   equal(response.id, 60244227);
-  //   equal(response.created_at, "2020-01-24T00:19:27Z");
-  // });
 });

--- a/tests/helpers/mock-fetch.ts
+++ b/tests/helpers/mock-fetch.ts
@@ -1,0 +1,69 @@
+//* Libraries imports
+import { mock } from "node:test";
+
+export type FetchMockHandler = (
+  url: string,
+  init?: RequestInit
+) => Promise<Response> | Response;
+
+/**
+ * Replaces global `fetch` with a mock handler for the duration of the current test.
+ * Call `mock.restoreAll()` in `afterEach` to clean up.
+ */
+export function mockFetch(handler: FetchMockHandler) {
+  return mock.method(
+    globalThis,
+    "fetch",
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+
+      return handler(url, init);
+    }
+  );
+}
+
+/**
+ * Builds a JSON `Response` suitable for Spellbinder's `response.json()` usage.
+ */
+export function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+/**
+ * Echo-style handler that mirrors hoppscotch/httpbin-like APIs used by the old tests.
+ * Returns method, path, query args and the request body as a string.
+ */
+export function createEchoHandler(method: string): FetchMockHandler {
+  return async (url, init) => {
+    const parsed = new URL(url);
+    const args: Record<string, string> = {};
+
+    parsed.searchParams.forEach((value, key) => {
+      args[key] = value;
+    });
+
+    let data = "";
+
+    if (typeof init?.body === "string") {
+      data = init.body;
+    } else if (init?.body instanceof FormData) {
+      data = JSON.stringify(Object.fromEntries(init.body.entries()));
+    }
+
+    return jsonResponse({
+      method,
+      args,
+      data,
+      path: parsed.pathname === "" ? "/" : parsed.pathname,
+    });
+  };
+}

--- a/tests/patch.test.ts
+++ b/tests/patch.test.ts
@@ -1,171 +1,197 @@
-import { test, it, describe } from "node:test";
-import { equal } from "node:assert";
+//* Libraries imports
+import { describe, it, afterEach, mock } from "node:test";
 import assert from "node:assert";
-
 import z from "zod";
 
+//* Local imports
 import { Spellbinder, SpellError } from "../src";
+import { mockFetch, createEchoHandler } from "./helpers/mock-fetch";
 
-test("Spellbinder Patch tests", async () => {
-  await it("should return the correct data", async () => {
-    const url = "/";
-    const spellbinder = new Spellbinder({
-      baseUrl: "https://echo.hoppscotch.io",
+describe("Spellbinder", () => {
+  describe("patch", () => {
+    afterEach(() => {
+      mock.restoreAll();
     });
 
-    const schema = z.object({
-      method: z.enum(["PATCH"]),
-      args: z.object({}),
-      data: z.string(),
-      path: z.string(),
-    });
+    it("returns validated data when the response matches the schema", async () => {
+      mockFetch(createEchoHandler("PATCH"));
 
-    const body = { data: "Hello, World!" };
+      const spellbinder = new Spellbinder({
+        baseUrl: "https://echo.example.com",
+      });
 
-    const response = await spellbinder.patch({
-      url,
-      schema,
-      body,
-    });
+      const schema = z.object({
+        method: z.enum(["PATCH"]),
+        args: z.object({}),
+        data: z.string(),
+        path: z.string(),
+      });
 
-    assert(response.data === JSON.stringify(body));
-  });
+      const body = { data: "Hello, World!" };
 
-  await it("should throw an error if the schema is incorrect", async () => {
-    const url = "/";
-    const spellbinder = new Spellbinder({
-      baseUrl: "https://echo.hoppscotch.io",
-    });
-
-    const schema = z.object({
-      method: z.enum(["PATCH"]),
-      args: z.object({}),
-      data: z.number(),
-      path: z.number(),
-    });
-
-    const body = { data: "Hello, World!" };
-
-    try {
-      await spellbinder.patch({
-        url,
+      const response = await spellbinder.patch({
+        url: "/",
         schema,
         body,
       });
-    } catch (error) {
-      assert(error instanceof SpellError);
-    }
-  });
 
-  await it("should work with custom headers", async () => {
-    const url = "/";
-    const spellbinder = new Spellbinder({
-      baseUrl: "https://echo.hoppscotch.io",
+      assert.equal(response.data, JSON.stringify(body));
     });
 
-    const schema = z.object({
-      method: z.enum(["PATCH"]),
-      args: z.object({}),
-      data: z.string(),
-      path: z.string(),
+    it("throws a SpellError when the response does not match the schema", async () => {
+      mockFetch(createEchoHandler("PATCH"));
+
+      const spellbinder = new Spellbinder({
+        baseUrl: "https://echo.example.com",
+      });
+
+      const schema = z.object({
+        method: z.enum(["PATCH"]),
+        args: z.object({}),
+        data: z.number(),
+        path: z.number(),
+      });
+
+      const body = { data: "Hello, World!" };
+
+      await assert.rejects(
+        () =>
+          spellbinder.patch({
+            url: "/",
+            schema,
+            body,
+          }),
+        (error: unknown) => error instanceof SpellError
+      );
     });
 
-    const body = { data: "Hello, World!" };
+    it("sends the request with custom headers", async () => {
+      const fetchMock = mockFetch(createEchoHandler("PATCH"));
 
-    const response = await spellbinder.patch({
-      url,
-      schema,
-      body,
-      headers: {
+      const spellbinder = new Spellbinder({
+        baseUrl: "https://echo.example.com",
+      });
+
+      const schema = z.object({
+        method: z.enum(["PATCH"]),
+        args: z.object({}),
+        data: z.string(),
+        path: z.string(),
+      });
+
+      const body = { data: "Hello, World!" };
+      const headers = {
         "Content-Type": "application/json",
-      },
+        "X-Custom-Header": "spellbinder",
+      };
+
+      const response = await spellbinder.patch({
+        url: "/",
+        schema,
+        body,
+        headers,
+      });
+
+      assert.equal(response.data, JSON.stringify(body));
+      assert.equal(fetchMock.mock.callCount(), 1);
+
+      const fetchInit = fetchMock.mock.calls[0]?.arguments[1] as
+        | RequestInit
+        | undefined;
+
+      assert.deepEqual(fetchInit?.headers, headers);
     });
 
-    assert(response.data === JSON.stringify(body));
-  });
+    it("requests the correct path for a nested route", async () => {
+      mockFetch(createEchoHandler("PATCH"));
 
-  await it("should work with another route", async () => {
-    const url = "/patch";
-    const spellbinder = new Spellbinder({
-      baseUrl: "https://echo.hoppscotch.io",
+      const spellbinder = new Spellbinder({
+        baseUrl: "https://echo.example.com",
+      });
+
+      const schema = z.object({
+        method: z.enum(["PATCH"]),
+        args: z.object({}),
+        data: z.string(),
+        path: z.literal("/patch"),
+      });
+
+      const body = { data: "Hello, World!" };
+
+      const response = await spellbinder.patch({
+        url: "/patch",
+        schema,
+        body,
+      });
+
+      assert.equal(response.data, JSON.stringify(body));
+      assert.equal(response.path, "/patch");
     });
 
-    const schema = z.object({
-      method: z.enum(["PATCH"]),
-      args: z.object({}),
-      data: z.string(),
-      path: z.literal("/patch"),
+    it("appends URL parameters to the request", async () => {
+      mockFetch(createEchoHandler("PATCH"));
+
+      const spellbinder = new Spellbinder({
+        baseUrl: "https://echo.example.com",
+      });
+
+      const params = { name: "John", age: "30" };
+
+      const schema = z.object({
+        method: z.enum(["PATCH"]),
+        data: z.string(),
+        path: z.literal("/patch"),
+        args: z.object({
+          name: z.literal("John"),
+          age: z.literal("30"),
+        }),
+      });
+
+      const body = { data: "Hello, World!" };
+
+      const response = await spellbinder.patch({
+        url: "/patch",
+        schema,
+        body,
+        params,
+      });
+
+      assert.equal(response.data, JSON.stringify(body));
+      assert.deepEqual(response.args, params);
     });
 
-    const body = { data: "Hello, World!" };
+    it("sends multipart/form-data bodies without throwing", async () => {
+      mockFetch(createEchoHandler("PATCH"));
 
-    const response = await spellbinder.patch({
-      url,
-      schema,
-      body,
-    });
+      const spellbinder = new Spellbinder({
+        baseUrl: "https://echo.example.com",
+      });
 
-    assert(response.data === JSON.stringify(body));
-  });
+      const params = { name: "John", age: "30" };
 
-  await it("should work with URL parameters", async () => {
-    const url = "/patch";
-    const spellbinder = new Spellbinder({
-      baseUrl: "https://echo.hoppscotch.io",
-    });
+      const schema = z.object({
+        method: z.enum(["PATCH"]),
+        data: z.string(),
+        path: z.literal("/"),
+        args: z.object({
+          name: z.literal("John"),
+          age: z.literal("30"),
+        }),
+      });
 
-    const params = { name: "John", age: "30" };
+      const body = new FormData();
+      body.append("name", "John");
+      body.append("age", "30");
 
-    const schema = z.object({
-      method: z.enum(["PATCH"]),
-      data: z.string(),
-      path: z.literal("/patch"),
-      args: z.object({
-        name: z.literal("John"),
-        age: z.literal("30"),
-      }),
-    });
+      const response = await spellbinder.patch({
+        url: "/",
+        schema,
+        body,
+        params,
+      });
 
-    const body = { data: "Hello, World!" };
-
-    const response = await spellbinder.patch({
-      url,
-      schema,
-      body,
-      params,
-    });
-
-    assert(response.data === JSON.stringify(body));
-  });
-
-  await it("Should be able to send multipart/form-data", async () => {
-    const url = "/";
-    const spellbinder = new Spellbinder({
-      baseUrl: "https://echo.hoppscotch.io",
-    });
-
-    const params = { name: "John", age: "30" };
-
-    const schema = z.object({
-      method: z.enum(["PATCH"]),
-      data: z.string(),
-      path: z.literal("/"),
-      args: z.object({
-        name: z.literal("John"),
-        age: z.literal("30"),
-      }),
-    });
-
-    const body = new FormData();
-
-    body.append("name", "John");
-    body.append("age", "30");
-
-    await spellbinder.patch({
-      url,
-      schema,
-      body,
-      params
+      assert.equal(response.method, "PATCH");
+      assert.deepEqual(response.args, params);
     });
   });
 });

--- a/tests/post.test.ts
+++ b/tests/post.test.ts
@@ -1,171 +1,197 @@
-import { test, it, describe } from "node:test";
-import { equal } from "node:assert";
+//* Libraries imports
+import { describe, it, afterEach, mock } from "node:test";
 import assert from "node:assert";
-
 import z from "zod";
 
+//* Local imports
 import { Spellbinder, SpellError } from "../src";
+import { mockFetch, createEchoHandler } from "./helpers/mock-fetch";
 
-test("Spellbinder Post tests", async () => {
-  await it("should return the correct data", async () => {
-    const url = "/";
-    const spellbinder = new Spellbinder({
-      baseUrl: "https://echo.hoppscotch.io",
+describe("Spellbinder", () => {
+  describe("post", () => {
+    afterEach(() => {
+      mock.restoreAll();
     });
 
-    const schema = z.object({
-      method: z.enum(["POST"]),
-      args: z.object({}),
-      data: z.string(),
-      path: z.string(),
-    });
+    it("returns validated data when the response matches the schema", async () => {
+      mockFetch(createEchoHandler("POST"));
 
-    const body = { data: "Hello, World!" };
+      const spellbinder = new Spellbinder({
+        baseUrl: "https://echo.example.com",
+      });
 
-    const response = await spellbinder.post({
-      url,
-      schema,
-      body,
-    });
+      const schema = z.object({
+        method: z.enum(["POST"]),
+        args: z.object({}),
+        data: z.string(),
+        path: z.string(),
+      });
 
-    assert(response.data === JSON.stringify(body));
-  });
+      const body = { data: "Hello, World!" };
 
-  await it("should throw an error if the schema is incorrect", async () => {
-    const url = "/";
-    const spellbinder = new Spellbinder({
-      baseUrl: "https://echo.hoppscotch.io",
-    });
-
-    const schema = z.object({
-      method: z.enum(["POST"]),
-      args: z.object({}),
-      data: z.number(),
-      path: z.number(),
-    });
-
-    const body = { data: "Hello, World!" };
-
-    try {
-      await spellbinder.post({
-        url,
+      const response = await spellbinder.post({
+        url: "/",
         schema,
         body,
       });
-    } catch (error) {
-      assert(error instanceof SpellError);
-    }
-  });
 
-  await it("should work with custom headers", async () => {
-    const url = "/";
-    const spellbinder = new Spellbinder({
-      baseUrl: "https://echo.hoppscotch.io",
+      assert.equal(response.data, JSON.stringify(body));
     });
 
-    const schema = z.object({
-      method: z.enum(["POST"]),
-      args: z.object({}),
-      data: z.string(),
-      path: z.string(),
+    it("throws a SpellError when the response does not match the schema", async () => {
+      mockFetch(createEchoHandler("POST"));
+
+      const spellbinder = new Spellbinder({
+        baseUrl: "https://echo.example.com",
+      });
+
+      const schema = z.object({
+        method: z.enum(["POST"]),
+        args: z.object({}),
+        data: z.number(),
+        path: z.number(),
+      });
+
+      const body = { data: "Hello, World!" };
+
+      await assert.rejects(
+        () =>
+          spellbinder.post({
+            url: "/",
+            schema,
+            body,
+          }),
+        (error: unknown) => error instanceof SpellError
+      );
     });
 
-    const body = { data: "Hello, World!" };
+    it("sends the request with custom headers", async () => {
+      const fetchMock = mockFetch(createEchoHandler("POST"));
 
-    const response = await spellbinder.post({
-      url,
-      schema,
-      body,
-      headers: {
+      const spellbinder = new Spellbinder({
+        baseUrl: "https://echo.example.com",
+      });
+
+      const schema = z.object({
+        method: z.enum(["POST"]),
+        args: z.object({}),
+        data: z.string(),
+        path: z.string(),
+      });
+
+      const body = { data: "Hello, World!" };
+      const headers = {
         "Content-Type": "application/json",
-      },
+        "X-Custom-Header": "spellbinder",
+      };
+
+      const response = await spellbinder.post({
+        url: "/",
+        schema,
+        body,
+        headers,
+      });
+
+      assert.equal(response.data, JSON.stringify(body));
+      assert.equal(fetchMock.mock.callCount(), 1);
+
+      const fetchInit = fetchMock.mock.calls[0]?.arguments[1] as
+        | RequestInit
+        | undefined;
+
+      assert.deepEqual(fetchInit?.headers, headers);
     });
 
-    assert(response.data === JSON.stringify(body));
-  });
+    it("requests the correct path for a nested route", async () => {
+      mockFetch(createEchoHandler("POST"));
 
-  await it("should work with another route", async () => {
-    const url = "/post";
-    const spellbinder = new Spellbinder({
-      baseUrl: "https://echo.hoppscotch.io",
+      const spellbinder = new Spellbinder({
+        baseUrl: "https://echo.example.com",
+      });
+
+      const schema = z.object({
+        method: z.enum(["POST"]),
+        args: z.object({}),
+        data: z.string(),
+        path: z.literal("/post"),
+      });
+
+      const body = { data: "Hello, World!" };
+
+      const response = await spellbinder.post({
+        url: "/post",
+        schema,
+        body,
+      });
+
+      assert.equal(response.data, JSON.stringify(body));
+      assert.equal(response.path, "/post");
     });
 
-    const schema = z.object({
-      method: z.enum(["POST"]),
-      args: z.object({}),
-      data: z.string(),
-      path: z.literal("/post"),
+    it("appends URL parameters to the request", async () => {
+      mockFetch(createEchoHandler("POST"));
+
+      const spellbinder = new Spellbinder({
+        baseUrl: "https://echo.example.com",
+      });
+
+      const params = { name: "John", age: "30" };
+
+      const schema = z.object({
+        method: z.enum(["POST"]),
+        data: z.string(),
+        path: z.literal("/post"),
+        args: z.object({
+          name: z.literal("John"),
+          age: z.literal("30"),
+        }),
+      });
+
+      const body = { data: "Hello, World!" };
+
+      const response = await spellbinder.post({
+        url: "/post",
+        schema,
+        body,
+        params,
+      });
+
+      assert.equal(response.data, JSON.stringify(body));
+      assert.deepEqual(response.args, params);
     });
 
-    const body = { data: "Hello, World!" };
+    it("sends multipart/form-data bodies without throwing", async () => {
+      mockFetch(createEchoHandler("POST"));
 
-    const response = await spellbinder.post({
-      url,
-      schema,
-      body,
-    });
+      const spellbinder = new Spellbinder({
+        baseUrl: "https://echo.example.com",
+      });
 
-    assert(response.data === JSON.stringify(body));
-  });
+      const params = { name: "John", age: "30" };
 
-  await it("should work with URL parameters", async () => {
-    const url = "/post";
-    const spellbinder = new Spellbinder({
-      baseUrl: "https://echo.hoppscotch.io",
-    });
+      const schema = z.object({
+        method: z.enum(["POST"]),
+        data: z.string(),
+        path: z.literal("/"),
+        args: z.object({
+          name: z.literal("John"),
+          age: z.literal("30"),
+        }),
+      });
 
-    const params = { name: "John", age: "30" };
+      const body = new FormData();
+      body.append("name", "John");
+      body.append("age", "30");
 
-    const schema = z.object({
-      method: z.enum(["POST"]),
-      data: z.string(),
-      path: z.literal("/post"),
-      args: z.object({
-        name: z.literal("John"),
-        age: z.literal("30"),
-      }),
-    });
+      const response = await spellbinder.post({
+        url: "/",
+        schema,
+        body,
+        params,
+      });
 
-    const body = { data: "Hello, World!" };
-
-    const response = await spellbinder.post({
-      url,
-      schema,
-      body,
-      params,
-    });
-
-    assert(response.data === JSON.stringify(body));
-  });
-
-  await it("Should be able to send multipart/form-data", async () => {
-    const url = "/";
-    const spellbinder = new Spellbinder({
-      baseUrl: "https://echo.hoppscotch.io",
-    });
-
-    const params = { name: "John", age: "30" };
-
-    const schema = z.object({
-      method: z.enum(["POST"]),
-      data: z.string(),
-      path: z.literal("/"),
-      args: z.object({
-        name: z.literal("John"),
-        age: z.literal("30"),
-      }),
-    });
-
-    const body = new FormData();
-
-    body.append("name", "John");
-    body.append("age", "30");
-
-    await spellbinder.post({
-      url,
-      schema,
-      body,
-      params
+      assert.equal(response.method, "POST");
+      assert.deepEqual(response.args, params);
     });
   });
 });

--- a/tests/put.test.ts
+++ b/tests/put.test.ts
@@ -1,171 +1,197 @@
-import { test, it, describe } from "node:test";
-import { equal } from "node:assert";
+//* Libraries imports
+import { describe, it, afterEach, mock } from "node:test";
 import assert from "node:assert";
-
 import z from "zod";
 
+//* Local imports
 import { Spellbinder, SpellError } from "../src";
+import { mockFetch, createEchoHandler } from "./helpers/mock-fetch";
 
-test("Spellbinder Put tests", async () => {
-  await it("should return the correct data", async () => {
-    const url = "/";
-    const spellbinder = new Spellbinder({
-      baseUrl: "https://echo.hoppscotch.io",
+describe("Spellbinder", () => {
+  describe("put", () => {
+    afterEach(() => {
+      mock.restoreAll();
     });
 
-    const schema = z.object({
-      method: z.enum(["PUT"]),
-      args: z.object({}),
-      data: z.string(),
-      path: z.string(),
-    });
+    it("returns validated data when the response matches the schema", async () => {
+      mockFetch(createEchoHandler("PUT"));
 
-    const body = { data: "Hello, World!" };
+      const spellbinder = new Spellbinder({
+        baseUrl: "https://echo.example.com",
+      });
 
-    const response = await spellbinder.put({
-      url,
-      schema,
-      body,
-    });
+      const schema = z.object({
+        method: z.enum(["PUT"]),
+        args: z.object({}),
+        data: z.string(),
+        path: z.string(),
+      });
 
-    assert(response.data === JSON.stringify(body));
-  });
+      const body = { data: "Hello, World!" };
 
-  await it("should throw an error if the schema is incorrect", async () => {
-    const url = "/";
-    const spellbinder = new Spellbinder({
-      baseUrl: "https://echo.hoppscotch.io",
-    });
-
-    const schema = z.object({
-      method: z.enum(["PUT"]),
-      args: z.object({}),
-      data: z.number(),
-      path: z.number(),
-    });
-
-    const body = { data: "Hello, World!" };
-
-    try {
-      await spellbinder.put({
-        url,
+      const response = await spellbinder.put({
+        url: "/",
         schema,
         body,
       });
-    } catch (error) {
-      assert(error instanceof SpellError);
-    }
-  });
 
-  await it("should work with custom headers", async () => {
-    const url = "/";
-    const spellbinder = new Spellbinder({
-      baseUrl: "https://echo.hoppscotch.io",
+      assert.equal(response.data, JSON.stringify(body));
     });
 
-    const schema = z.object({
-      method: z.enum(["PUT"]),
-      args: z.object({}),
-      data: z.string(),
-      path: z.string(),
+    it("throws a SpellError when the response does not match the schema", async () => {
+      mockFetch(createEchoHandler("PUT"));
+
+      const spellbinder = new Spellbinder({
+        baseUrl: "https://echo.example.com",
+      });
+
+      const schema = z.object({
+        method: z.enum(["PUT"]),
+        args: z.object({}),
+        data: z.number(),
+        path: z.number(),
+      });
+
+      const body = { data: "Hello, World!" };
+
+      await assert.rejects(
+        () =>
+          spellbinder.put({
+            url: "/",
+            schema,
+            body,
+          }),
+        (error: unknown) => error instanceof SpellError
+      );
     });
 
-    const body = { data: "Hello, World!" };
+    it("sends the request with custom headers", async () => {
+      const fetchMock = mockFetch(createEchoHandler("PUT"));
 
-    const response = await spellbinder.put({
-      url,
-      schema,
-      body,
-      headers: {
+      const spellbinder = new Spellbinder({
+        baseUrl: "https://echo.example.com",
+      });
+
+      const schema = z.object({
+        method: z.enum(["PUT"]),
+        args: z.object({}),
+        data: z.string(),
+        path: z.string(),
+      });
+
+      const body = { data: "Hello, World!" };
+      const headers = {
         "Content-Type": "application/json",
-      },
+        "X-Custom-Header": "spellbinder",
+      };
+
+      const response = await spellbinder.put({
+        url: "/",
+        schema,
+        body,
+        headers,
+      });
+
+      assert.equal(response.data, JSON.stringify(body));
+      assert.equal(fetchMock.mock.callCount(), 1);
+
+      const fetchInit = fetchMock.mock.calls[0]?.arguments[1] as
+        | RequestInit
+        | undefined;
+
+      assert.deepEqual(fetchInit?.headers, headers);
     });
 
-    assert(response.data === JSON.stringify(body));
-  });
+    it("requests the correct path for a nested route", async () => {
+      mockFetch(createEchoHandler("PUT"));
 
-  await it("should work with another route", async () => {
-    const url = "/put";
-    const spellbinder = new Spellbinder({
-      baseUrl: "https://echo.hoppscotch.io",
+      const spellbinder = new Spellbinder({
+        baseUrl: "https://echo.example.com",
+      });
+
+      const schema = z.object({
+        method: z.enum(["PUT"]),
+        args: z.object({}),
+        data: z.string(),
+        path: z.literal("/put"),
+      });
+
+      const body = { data: "Hello, World!" };
+
+      const response = await spellbinder.put({
+        url: "/put",
+        schema,
+        body,
+      });
+
+      assert.equal(response.data, JSON.stringify(body));
+      assert.equal(response.path, "/put");
     });
 
-    const schema = z.object({
-      method: z.enum(["PUT"]),
-      args: z.object({}),
-      data: z.string(),
-      path: z.literal("/put"),
+    it("appends URL parameters to the request", async () => {
+      mockFetch(createEchoHandler("PUT"));
+
+      const spellbinder = new Spellbinder({
+        baseUrl: "https://echo.example.com",
+      });
+
+      const params = { name: "John", age: "30" };
+
+      const schema = z.object({
+        method: z.enum(["PUT"]),
+        data: z.string(),
+        path: z.literal("/put"),
+        args: z.object({
+          name: z.literal("John"),
+          age: z.literal("30"),
+        }),
+      });
+
+      const body = { data: "Hello, World!" };
+
+      const response = await spellbinder.put({
+        url: "/put",
+        schema,
+        body,
+        params,
+      });
+
+      assert.equal(response.data, JSON.stringify(body));
+      assert.deepEqual(response.args, params);
     });
 
-    const body = { data: "Hello, World!" };
+    it("sends multipart/form-data bodies without throwing", async () => {
+      mockFetch(createEchoHandler("PUT"));
 
-    const response = await spellbinder.put({
-      url,
-      schema,
-      body,
-    });
+      const spellbinder = new Spellbinder({
+        baseUrl: "https://echo.example.com",
+      });
 
-    assert(response.data === JSON.stringify(body));
-  });
+      const params = { name: "John", age: "30" };
 
-  await it("should work with URL parameters", async () => {
-    const url = "/put";
-    const spellbinder = new Spellbinder({
-      baseUrl: "https://echo.hoppscotch.io",
-    });
+      const schema = z.object({
+        method: z.enum(["PUT"]),
+        data: z.string(),
+        path: z.literal("/"),
+        args: z.object({
+          name: z.literal("John"),
+          age: z.literal("30"),
+        }),
+      });
 
-    const params = { name: "John", age: "30" };
+      const body = new FormData();
+      body.append("name", "John");
+      body.append("age", "30");
 
-    const schema = z.object({
-      method: z.enum(["PUT"]),
-      data: z.string(),
-      path: z.literal("/put"),
-      args: z.object({
-        name: z.literal("John"),
-        age: z.literal("30"),
-      }),
-    });
+      const response = await spellbinder.put({
+        url: "/",
+        schema,
+        body,
+        params,
+      });
 
-    const body = { data: "Hello, World!" };
-
-    const response = await spellbinder.put({
-      url,
-      schema,
-      body,
-      params,
-    });
-
-    assert(response.data === JSON.stringify(body));
-  });
-
-  await it("Should be able to send multipart/form-data", async () => {
-    const url = "/";
-    const spellbinder = new Spellbinder({
-      baseUrl: "https://echo.hoppscotch.io",
-    });
-
-    const params = { name: "John", age: "30" };
-
-    const schema = z.object({
-      method: z.enum(["PUT"]),
-      data: z.string(),
-      path: z.literal("/"),
-      args: z.object({
-        name: z.literal("John"),
-        age: z.literal("30"),
-      }),
-    });
-
-    const body = new FormData();
-
-    body.append("name", "John");
-    body.append("age", "30");
-
-    await spellbinder.put({
-      url,
-      schema,
-      body,
-      params
+      assert.equal(response.method, "PUT");
+      assert.deepEqual(response.args, params);
     });
   });
 });

--- a/tests/safeGet.test.ts
+++ b/tests/safeGet.test.ts
@@ -1,49 +1,122 @@
-import { test, it, describe } from "node:test";
-import { equal } from "node:assert";
+//* Libraries imports
+import { describe, it, afterEach, mock } from "node:test";
 import assert from "node:assert";
-
 import z from "zod";
 
-import { Spellbinder, SpellError } from "../src";
+//* Local imports
+import { Spellbinder } from "../src";
+import { mockFetch, jsonResponse } from "./helpers/mock-fetch";
 
-test("Spellbinder safeGet test", async () => {
-
-  await it("should return error if the schema is not correct", async () => {
-    const url = "/users/tamicktom";
-    const spellbinder = new Spellbinder({ baseUrl: "https://api.github.com/" });
-
-    const schema = z.object({
-      login: z.string(),
-      id: z.number(),
-      followers: z.number(),
-      following: z.number(),
-      created_at: z.string(),
-      updated_at: z.string(),
+describe("Spellbinder", () => {
+  describe("safeGet", () => {
+    afterEach(() => {
+      mock.restoreAll();
     });
 
-    const banana = await spellbinder.safeGet({ url, schema: schema.array() });
+    it("returns success with validated data when the response matches the schema", async () => {
+      mockFetch(() =>
+        jsonResponse({
+          login: "Tamicktom",
+          id: 60244227,
+          followers: 10,
+          following: 5,
+          created_at: "2020-01-24T00:19:27Z",
+          updated_at: "2024-01-01T00:00:00Z",
+        })
+      );
 
-    assert(banana.success === false);
-    assert(banana.error.errors.length === 1);
-    assert(banana.error instanceof z.ZodError);
-  });
+      const spellbinder = new Spellbinder({
+        baseUrl: "https://api.github.com/",
+      });
 
-  await it("should return an error if the url is not correct", async () => {
-    const url = "users";
-    const spellbinder = new Spellbinder({ baseUrl: "https://api.github.com" });
+      const schema = z.object({
+        login: z.string(),
+        id: z.number(),
+        followers: z.number(),
+        following: z.number(),
+        created_at: z.string(),
+        updated_at: z.string(),
+      });
 
-    const schema = z.object({
-      login: z.string(),
-      id: z.number(),
-      followers: z.number(),
-      following: z.number(),
-      created_at: z.string(),
-      updated_at: z.string(),
+      const result = await spellbinder.safeGet({
+        url: "/users/tamicktom",
+        schema,
+      });
+
+      assert.equal(result.success, true);
+      if (result.success) {
+        assert.equal(result.data.login, "Tamicktom");
+        assert.equal(result.data.id, 60244227);
+      }
     });
 
-    const user = await spellbinder.safeGet({ url, schema });
+    it("returns an error when the response does not match the schema", async () => {
+      mockFetch(() =>
+        jsonResponse({
+          login: "Tamicktom",
+          id: 60244227,
+          followers: 10,
+          following: 5,
+          created_at: "2020-01-24T00:19:27Z",
+          updated_at: "2024-01-01T00:00:00Z",
+        })
+      );
 
-    assert(user.success === false);
-    assert(user.error instanceof z.ZodError);
+      const spellbinder = new Spellbinder({
+        baseUrl: "https://api.github.com/",
+      });
+
+      const schema = z.object({
+        login: z.string(),
+        id: z.number(),
+        followers: z.number(),
+        following: z.number(),
+        created_at: z.string(),
+        updated_at: z.string(),
+      });
+
+      const result = await spellbinder.safeGet({
+        url: "/users/tamicktom",
+        schema: schema.array(),
+      });
+
+      assert.equal(result.success, false);
+      if (!result.success) {
+        assert.equal(result.error.errors.length, 1);
+        assert.ok(result.error instanceof z.ZodError);
+      }
+    });
+
+    it("returns an error when the response body is incompatible with the schema", async () => {
+      mockFetch(() =>
+        jsonResponse({
+          message: "Not Found",
+          documentation_url: "https://docs.github.com/rest",
+        })
+      );
+
+      const spellbinder = new Spellbinder({
+        baseUrl: "https://api.github.com",
+      });
+
+      const schema = z.object({
+        login: z.string(),
+        id: z.number(),
+        followers: z.number(),
+        following: z.number(),
+        created_at: z.string(),
+        updated_at: z.string(),
+      });
+
+      const result = await spellbinder.safeGet({
+        url: "users",
+        schema,
+      });
+
+      assert.equal(result.success, false);
+      if (!result.success) {
+        assert.ok(result.error instanceof z.ZodError);
+      }
+    });
   });
 });

--- a/tests/url.test.ts
+++ b/tests/url.test.ts
@@ -1,53 +1,57 @@
-import { test, it, describe } from "node:test";
+//* Libraries imports
+import { describe, it } from "node:test";
 import { equal } from "node:assert";
-import assert from "node:assert";
 
-import z from "zod";
+//* Local imports
+import { createUrl, createUrlArgs, mergeUrls } from "../src/utils";
 
-import {
-  createUrl,
-  createUrlArgs,
-  fixUrlEnd,
-  fixUrlStart,
-  getDefaultHeaders,
-  mergeUrls
-} from "../src/utils";
+describe("URL utilities", () => {
+  describe("mergeUrls", () => {
+    it("concatenates the base URL with a path that starts with a slash", () => {
+      const url = "/users/tamicktom";
+      const baseUrl = "https://echo.example.com";
 
-test("Url Params functions test", async () => {
-  await it("should return the correct url", async () => {
-    const url = "/users/tamicktom";
-    const baseIrl = "https://echo.hoppscotch.io";
+      const mergedUrl = mergeUrls(baseUrl, url);
 
-    const mergedUrl = mergeUrls(baseIrl, url);
-
-    equal(mergedUrl, "https://echo.hoppscotch.io/users/tamicktom");
+      equal(mergedUrl, "https://echo.example.com/users/tamicktom");
+    });
   });
 
-  await it("should create the right url with url params", async () => {
-    const params = { page: 1, limit: 10 };
+  describe("createUrlArgs", () => {
+    it("builds a query string from an object of parameters", () => {
+      const params = { page: 1, limit: 10 };
 
-    const urlParams = createUrlArgs(params);
+      const urlParams = createUrlArgs(params);
 
-    equal(urlParams, "?page=1&limit=10");
+      equal(urlParams, "?page=1&limit=10");
+    });
   });
 
-  await it("should create the right url with url params and base url", async () => {
-    const params = { page: 1, limit: 10 };
-    const baseUrl = "https://echo.hoppscotch.io";
-    const url = "/users/tamicktom";
+  describe("createUrl", () => {
+    it("builds a full URL when the path starts with a slash", () => {
+      const params = { page: 1, limit: 10 };
+      const baseUrl = "https://echo.example.com";
+      const url = "/users/tamicktom";
 
-    const urlWithParams = createUrl(baseUrl, url, params);
+      const urlWithParams = createUrl(baseUrl, url, params);
 
-    equal(urlWithParams, "https://echo.hoppscotch.io/users/tamicktom?page=1&limit=10");
-  });
+      equal(
+        urlWithParams,
+        "https://echo.example.com/users/tamicktom?page=1&limit=10"
+      );
+    });
 
-  await it("should create the right url with url params and base url", async () => {
-    const params = { page: 1, limit: 10 };
-    const baseUrl = "https://echo.hoppscotch.io";
-    const url = "users/tamicktom";
+    it("builds a full URL when the path does not start with a slash", () => {
+      const params = { page: 1, limit: 10 };
+      const baseUrl = "https://echo.example.com";
+      const url = "users/tamicktom";
 
-    const urlWithParams = createUrl(baseUrl, url, params);
+      const urlWithParams = createUrl(baseUrl, url, params);
 
-    equal(urlWithParams, "https://echo.hoppscotch.io/users/tamicktom?page=1&limit=10");
+      equal(
+        urlWithParams,
+        "https://echo.example.com/users/tamicktom?page=1&limit=10"
+      );
+    });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Mock all HTTP calls via `tests/helpers/mock-fetch.ts` so tests no longer depend on `api.github.com` or `echo.hoppscotch.io`
- Rename suites to BDD-style `describe` / `it` naming focused on behavior
- Scope the `test` script to `./tests/**/*.test.ts` and update `AGENTS.md` accordingly

## Test plan
- [x] `pnpm run lint`
- [x] `pnpm run test` (29 passing, no network)
- [x] Isolated `node --import tsx --test ./tests/get.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5bdda005-20ce-48f1-a3b4-923396dc6de7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5bdda005-20ce-48f1-a3b4-923396dc6de7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

